### PR TITLE
[Enhancement] use the user serializer in the request serializer

### DIFF
--- a/.github/workflows/on-pull-request-workflow.yml
+++ b/.github/workflows/on-pull-request-workflow.yml
@@ -13,21 +13,7 @@ jobs:
       matrix:
         python-version: [3.8]
         poetry-version: [1.1.6]
-        include:
-          - db: mysql
-            db_port: 3306
-    services:
-      mysql:
-        image: mysql:5.7
-        env:
-          MYSQL_ROOT_PASSWORD: "p@ssw0rd"
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd="mysqladmin ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=3
+
     steps:
       - uses: actions/checkout@v2
 

--- a/Squest/settings.py
+++ b/Squest/settings.py
@@ -400,3 +400,23 @@ METRICS_ENABLED = str_to_bool(os.environ.get('METRICS_ENABLED', False))
 METRICS_PASSWORD_PROTECTED = str_to_bool(os.environ.get('METRICS_PASSWORD_PROTECTED', True))
 METRICS_AUTHORIZATION_USERNAME = os.environ.get('METRICS_AUTHORIZATION_USERNAME', 'admin')
 METRICS_AUTHORIZATION_PASSWORD = os.environ.get('METRICS_AUTHORIZATION_PASSWORD', 'admin')
+
+# -----------------------------------------
+# Testing settings
+# -----------------------------------------
+if TESTING:
+    import logging
+    logging.disable(logging.CRITICAL)
+    DEBUG = False
+    TEMPLATE_DEBUG = False
+    PASSWORD_HASHERS = [
+        'django.contrib.auth.hashers.MD5PasswordHasher',
+    ]
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': ':memory:',
+        }
+    }
+
+print('[Settings] loaded')

--- a/monitoring/apps.py
+++ b/monitoring/apps.py
@@ -9,7 +9,7 @@ class MonitoringConfig(AppConfig):
     name = 'monitoring'
 
     def ready(self):
-        if 'manage.py' not in sys.argv:
+        if 'manage.py' not in sys.argv and 'test' not in sys.argv:
             from .models import ComponentCollector
             prometheus_client.REGISTRY.register(ComponentCollector())
             # Unregister default metrics

--- a/profiles/api/serializers/user_serializers.py
+++ b/profiles/api/serializers/user_serializers.py
@@ -1,8 +1,32 @@
+from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import User
 from rest_framework import serializers
 
+from profiles.models import Profile
+
+
+class ProfileSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Profile
+        fields = ['notification_enabled', 'subscribed_services_notification']
+
 
 class UserSerializer(serializers.ModelSerializer):
+
+    profile = ProfileSerializer(required=False)
+    password = serializers.CharField(
+        write_only=True,
+        required=True,
+        help_text='Leave empty if no change needed',
+        style={'input_type': 'password', 'placeholder': 'Password'}
+    )
+
+    def create(self, validated_data):
+        validated_data['password'] = make_password(validated_data.get('password'))
+        return super(UserSerializer, self).create(validated_data)
+
     class Meta:
         model = User
-        fields = '__all__'
+        fields = ['id', 'username', 'password', 'email', 'profile', 'first_name', 'last_name', 'is_staff',
+                  'is_superuser', 'is_active']

--- a/service_catalog/models/request.py
+++ b/service_catalog/models/request.py
@@ -210,7 +210,7 @@ class Request(RoleManager):
         if created:
             if instance.user:
                 instance.add_user_in_role(instance.user, "Admin")
-            instance_content_type = ContentType.objects.get_for_model(Request)
+            instance_content_type = ContentType.objects.get_for_model(Instance)
             user_bindings = UserRoleBinding.objects.filter(
                 content_type=instance_content_type,
                 object_id=instance.instance.id

--- a/service_catalog/serializers/request_serializers.py
+++ b/service_catalog/serializers/request_serializers.py
@@ -3,6 +3,7 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.relations import PrimaryKeyRelatedField
 from rest_framework.serializers import ModelSerializer, CharField, ValidationError
 
+from profiles.api.serializers.user_serializers import UserSerializer
 from profiles.models import BillingGroup
 from service_catalog.forms import FormUtils
 from service_catalog.models import Request, Service, OperationType, Operation, Instance
@@ -104,6 +105,7 @@ class RequestSerializer(ModelSerializer):
         read_only = True
 
     instance = InstanceSerializer(read_only=True)
+    user = UserSerializer(read_only=True)
 
 
 class AdminRequestSerializer(ModelSerializer):
@@ -112,3 +114,4 @@ class AdminRequestSerializer(ModelSerializer):
         exclude = ['periodic_task', 'periodic_task_date_expire', 'failure_message']
 
     instance = InstanceSerializer(read_only=True)
+    user = UserSerializer(read_only=True)

--- a/tests/test_profile/test_api/test_user/test_user_create.py
+++ b/tests/test_profile/test_api/test_user/test_user_create.py
@@ -2,7 +2,6 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 
 from tests.test_service_catalog.base_test_request import BaseTestRequest
-from tests.utils import check_data_in_dict
 
 
 class TestApiUserCreate(BaseTestRequest):
@@ -19,9 +18,9 @@ class TestApiUserCreate(BaseTestRequest):
         response = self.client.post(self.create_user_url, data=self.post_data,
                                     content_type="application/json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        check_data_in_dict(self, [{
-            'username': "myUsername",
-        }], [response.data])
+        self.assertEqual(set(response.data.keys()),
+                         {'id', 'last_name', 'first_name', 'is_staff', 'email',
+                          'profile', 'username', 'is_superuser', 'is_active'})
 
     def _create_user_failed(self, status_error=status.HTTP_400_BAD_REQUEST):
         response = self.client.post(self.create_user_url, data=self.post_data,

--- a/tests/test_profile/test_api/test_user/test_user_create.py
+++ b/tests/test_profile/test_api/test_user/test_user_create.py
@@ -19,7 +19,9 @@ class TestApiUserCreate(BaseTestRequest):
         response = self.client.post(self.create_user_url, data=self.post_data,
                                     content_type="application/json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        check_data_in_dict(self, [self.post_data], [response.data])
+        check_data_in_dict(self, [{
+            'username': "myUsername",
+        }], [response.data])
 
     def _create_user_failed(self, status_error=status.HTTP_400_BAD_REQUEST):
         response = self.client.post(self.create_user_url, data=self.post_data,

--- a/tests/test_profile/test_api/test_user/test_user_details.py
+++ b/tests/test_profile/test_api/test_user/test_user_details.py
@@ -22,8 +22,8 @@ class TestApiUserDetails(BaseTestRequest):
             'is_staff': self.standard_user.is_staff,
             'is_superuser': self.standard_user.is_superuser,
             'is_active': self.standard_user.is_active,
-            'groups': list(self.standard_user.groups.all()),
-            'user_permissions': list(self.standard_user.user_permissions.all()),
+            # 'groups': list(self.standard_user.groups.all()),
+            # 'user_permissions': list(self.standard_user.user_permissions.all()),
         }
         self.expected_data_list = [self.expected_data]
 

--- a/tests/test_profile/test_api/test_user/test_user_patch.py
+++ b/tests/test_profile/test_api/test_user/test_user_patch.py
@@ -25,8 +25,8 @@ class TestApiUserPatch(BaseTestRequest):
             'is_staff': self.standard_user.is_staff,
             'is_superuser': self.standard_user.is_superuser,
             'is_active': self.standard_user.is_active,
-            'groups': list(self.standard_user.groups.all()),
-            'user_permissions': list(self.standard_user.user_permissions.all()),
+            # 'groups': list(self.standard_user.groups.all()),
+            # 'user_permissions': list(self.standard_user.user_permissions.all()),
         }
 
     def test_admin_patch_user(self):

--- a/tests/test_profile/test_api/test_user/test_user_put.py
+++ b/tests/test_profile/test_api/test_user/test_user_put.py
@@ -26,8 +26,8 @@ class TestApiUserPatch(BaseTestRequest):
             'is_staff': self.standard_user.is_staff,
             'is_superuser': self.standard_user.is_superuser,
             'is_active': self.standard_user.is_active,
-            'groups': list(self.standard_user.groups.all()),
-            'user_permissions': list(self.standard_user.user_permissions.all()),
+            # 'groups': list(self.standard_user.groups.all()),
+            # 'user_permissions': list(self.standard_user.user_permissions.all()),
         }
 
     def test_admin_put_user(self):

--- a/tests/test_resource_tracker/test_api/test_resource_api_views/test_create.py
+++ b/tests/test_resource_tracker/test_api/test_resource_api_views/test_create.py
@@ -92,7 +92,7 @@ class TestResourceCreate(BaseTestAPI):
                     "value": "12"
                 },
                 {
-                    "name": "memory",
+                    "name": "Memory",
                     "value": "20"
                 }
             ],
@@ -119,7 +119,7 @@ class TestResourceCreate(BaseTestAPI):
                     "value": "12"
                 },
                 {
-                    "name": "memory",
+                    "name": "Memory",
                     "value": "20"
                 }
             ],

--- a/tests/test_service_catalog/base_test_request.py
+++ b/tests/test_service_catalog/base_test_request.py
@@ -8,7 +8,8 @@ class BaseTestRequest(BaseTest):
     def setUp(self):
         super(BaseTestRequest, self).setUp()
         form_data = {'instance_name': 'test instance', 'text_variable': 'my_var'}
-        self.test_instance = Instance.objects.create(name="test_instance_1", service=self.service_test,
+        self.test_instance = Instance.objects.create(name="test_instance_1",
+                                                     service=self.service_test,
                                                      spoc=self.standard_user)
 
         # add a first request
@@ -20,7 +21,8 @@ class BaseTestRequest(BaseTest):
         self.support_test = Support.objects.create(title="support_1", instance=self.test_instance)
 
         # second instance for second user
-        self.test_instance_2 = Instance.objects.create(name="test_instance_2", service=self.service_test,
+        self.test_instance_2 = Instance.objects.create(name="test_instance_2",
+                                                       service=self.service_test,
                                                        spoc=self.standard_user_2)
 
         self.rg_physical_servers = ResourceGroup.objects.create(name="Physical servers")

--- a/tests/test_service_catalog/test_api/test_request/test_request_delete.py
+++ b/tests/test_service_catalog/test_api/test_request/test_request_delete.py
@@ -17,7 +17,7 @@ class TestApiRequestDelete(BaseTestRequest):
         )
         self.test_request_standard_user_2 = Request.objects.create(
             fill_in_survey={},
-            instance=self.test_instance,
+            instance=self.test_instance_2,
             operation=self.create_operation_test,
             user=self.standard_user_2
         )
@@ -61,9 +61,10 @@ class TestApiRequestDelete(BaseTestRequest):
     def test_customer_cannot_delete_non_owned_request_canceled(self):
         self.test_request_standard_user_2.state = RequestState.CANCELED
         self.test_request_standard_user_2.save()
-        self.client.force_login(user=self.standard_user)
         self.kwargs['pk'] = self.test_request_standard_user_2.id
         self.get_request_details_url = reverse('api_request_details', kwargs=self.kwargs)
+        self.client.logout()
+        self.client.force_login(user=self.standard_user)
         response = self.client.delete(self.get_request_details_url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 

--- a/tests/test_service_catalog/test_api/test_request/test_request_details.py
+++ b/tests/test_service_catalog/test_api/test_request/test_request_details.py
@@ -25,13 +25,13 @@ class TestApiRequestDetails(BaseTestRequest):
         )
         self.test_request_standard_user_2 = Request.objects.create(
             fill_in_survey={},
-            instance=self.test_instance,
+            instance=self.test_instance_2,
             operation=self.create_operation_test,
             user=self.standard_user_2
         )
         Request.objects.create(
             fill_in_survey={},
-            instance=self.test_instance,
+            instance=self.test_instance_2,
             operation=self.update_operation_test,
             user=self.standard_user_2
         )

--- a/tests/test_service_catalog/test_api/test_request/test_request_details.py
+++ b/tests/test_service_catalog/test_api/test_request/test_request_details.py
@@ -1,6 +1,7 @@
 from rest_framework import status
 from rest_framework.reverse import reverse
 
+from profiles.api.serializers.user_serializers import UserSerializer
 from service_catalog.models import Request
 from tests.test_service_catalog.base_test_request import BaseTestRequest
 from tests.utils import check_data_in_dict
@@ -44,7 +45,8 @@ class TestApiRequestDetails(BaseTestRequest):
             'tower_job_id': self.test_request_standard_user_1.tower_job_id,
             'state': self.test_request_standard_user_1.state,
             'operation': self.test_request_standard_user_1.operation.id,
-            'user': self.test_request_standard_user_1.user.id}
+            'user': UserSerializer(instance=self.test_request_standard_user_1.user).data
+        }
         self.expected_instance = {
             'id': self.test_request_standard_user_1.instance.id,
             'state': self.test_request_standard_user_1.instance.state,

--- a/tests/test_service_catalog/test_api/test_request/test_request_patch.py
+++ b/tests/test_service_catalog/test_api/test_request/test_request_patch.py
@@ -1,6 +1,7 @@
 from rest_framework import status
 from rest_framework.reverse import reverse
 
+from profiles.api.serializers.user_serializers import UserSerializer
 from service_catalog.models import Request, RequestState
 from tests.test_service_catalog.base_test_request import BaseTestRequest
 from tests.utils import check_data_in_dict
@@ -36,7 +37,7 @@ class TestApiRequestPatch(BaseTestRequest):
             'tower_job_id': self.test_request_standard_user_1.tower_job_id,
             'state': RequestState.NEED_INFO,
             'operation': self.update_operation_test.id,
-            'user': self.test_request_standard_user_1.user.id
+            'user': UserSerializer(self.test_request_standard_user_1.user).data
         }
 
     def test_admin_patch_request(self):

--- a/tests/test_service_catalog/test_api/test_request/test_request_put.py
+++ b/tests/test_service_catalog/test_api/test_request/test_request_put.py
@@ -38,13 +38,8 @@ class TestApiRequestPut(BaseTestRequest):
     def test_admin_put_on_request(self):
         response = self.client.put(self.get_request_details_url, data=self.put_data, content_type="application/json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        expected = {
-            'fill_in_survey': dict(),
-            'tower_job_id': 6,
-            'state': RequestState.NEED_INFO,
-            'operation': self.update_operation_test.id,
-            'user': UserSerializer(instance=self.standard_user).data
-        }
+        expected = self.put_data
+        expected['user'] = UserSerializer(instance=self.standard_user).data
         check_data_in_dict(self, [expected], [response.data])
 
     def test_admin_cannot_put_on_request_not_full(self):

--- a/tests/test_service_catalog/test_api/test_request/test_request_put.py
+++ b/tests/test_service_catalog/test_api/test_request/test_request_put.py
@@ -1,6 +1,7 @@
 from rest_framework import status
 from rest_framework.reverse import reverse
 
+from profiles.api.serializers.user_serializers import UserSerializer
 from service_catalog.models import Request, RequestState
 from tests.test_service_catalog.base_test_request import BaseTestRequest
 from tests.utils import check_data_in_dict
@@ -27,7 +28,7 @@ class TestApiRequestPut(BaseTestRequest):
             'tower_job_id': 6,
             'state': RequestState.NEED_INFO,
             'operation': self.update_operation_test.id,
-            'user': self.standard_user_2.id
+            'user': {'id': self.standard_user.id}
         }
         self.kwargs = {
             'pk': self.test_request_standard_user_1.id
@@ -37,7 +38,14 @@ class TestApiRequestPut(BaseTestRequest):
     def test_admin_put_on_request(self):
         response = self.client.put(self.get_request_details_url, data=self.put_data, content_type="application/json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        check_data_in_dict(self, [self.put_data], [response.data])
+        expected = {
+            'fill_in_survey': dict(),
+            'tower_job_id': 6,
+            'state': RequestState.NEED_INFO,
+            'operation': self.update_operation_test.id,
+            'user': UserSerializer(instance=self.standard_user).data
+        }
+        check_data_in_dict(self, [expected], [response.data])
 
     def test_admin_cannot_put_on_request_not_full(self):
         self.put_data.pop('operation')

--- a/tests/test_service_catalog/test_models/test_request.py
+++ b/tests/test_service_catalog/test_models/test_request.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from django_celery_beat.models import PeriodicTask, IntervalSchedule, CrontabSchedule
 from django_fsm import can_proceed
 
+from profiles.api.serializers.user_serializers import UserSerializer
 from service_catalog.models.instance import InstanceState, Instance
 from service_catalog.models.request import RequestState, Request
 from tests.test_service_catalog.base_test_request import BaseTestRequest
@@ -39,6 +40,7 @@ class TestRequest(BaseTestRequest):
                 'id': self.test_request.id,
                 'state': RequestState.PROCESSING,
                 'operation': self.test_request.operation.id,
+                'user': UserSerializer(self.test_request.user).data
             }
             expected_instance = {
                 'id': self.test_instance.id,
@@ -49,13 +51,15 @@ class TestRequest(BaseTestRequest):
                 'billing_group': None,
                 'spoc': self.test_request.instance.spoc.id
             }
+            expected_user = UserSerializer(self.test_request.user).data
             mock_job_execute.assert_called()
             kwargs = mock_job_execute.call_args[1]
-            expected_data_list = [expected_extra_vars, expected_request, expected_instance]
+            expected_data_list = [expected_extra_vars, expected_request, expected_instance, expected_user]
             data_list = [
                 kwargs.get("extra_vars", None),
                 kwargs.get("extra_vars", None).get('squest', None).get('request', None),
-                kwargs.get("extra_vars", None).get('squest', None).get('request', None).get('instance', None)
+                kwargs.get("extra_vars", None).get('squest', None).get('request', None).get('instance', None),
+                kwargs.get("extra_vars", None).get('squest', None).get('request', None).get('user', None)
             ]
             for expected_data, data in zip(expected_data_list, data_list):
                 for key_var, val_var in expected_data.items():

--- a/tests/test_service_catalog/test_serializers/test_user_serializer.py
+++ b/tests/test_service_catalog/test_serializers/test_user_serializer.py
@@ -1,0 +1,25 @@
+from tests.test_service_catalog.base import BaseTest
+from profiles.api.serializers.user_serializers import UserSerializer
+
+
+class TestUserSerializer(BaseTest):
+
+    def setUp(self):
+        super(TestUserSerializer, self).setUp()
+        self.superuser.profile.notification_enabled = True
+        self.superuser.profile.subscribed_services_notification.add(self.service_test)
+        self.superuser.profile.save()
+
+    def test_contains_expected_fields(self):
+        serializer = UserSerializer(instance=self.superuser)
+        self.assertEqual(set(serializer.data.keys()),
+                         {'id', 'last_name', 'first_name', 'is_staff', 'email',
+                          'profile', 'username', 'is_superuser', 'is_active'})
+
+    def test_user_field_content(self):
+        serializer = UserSerializer(instance=self.superuser)
+        self.assertEqual(serializer.data['id'], self.superuser.id)
+        self.assertEqual(serializer.data['email'], self.superuser.email)
+        self.assertEqual(serializer.data['username'], self.superuser.username)
+        self.assertEqual(serializer.data['profile']['notification_enabled'], True)
+        self.assertEqual(serializer.data['profile']['subscribed_services_notification'], [self.service_test.id])


### PR DESCRIPTION
So Tower receive a complete info about the user instead of just an ID