### PR TITLE
[Enhancement] use billing group serializer in instance serializer

### DIFF
--- a/service_catalog/serializers/instance_serializer.py
+++ b/service_catalog/serializers/instance_serializer.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 
+from profiles.api.serializers.billing_group_serializers import BillingGroupSerializer
 from resource_tracker.api.serializers.resource_group.resource_serializers import ResourceSerializer
 from service_catalog.models import Instance, InstanceState
 
@@ -7,6 +8,7 @@ from service_catalog.models import Instance, InstanceState
 class InstanceSerializer(serializers.ModelSerializer):
     state = serializers.ChoiceField(choices=InstanceState.choices)
     resources = ResourceSerializer(many=True, read_only=True)
+    billing_group = BillingGroupSerializer(read_only=True)
 
     class Meta:
         model = Instance

--- a/tests/test_service_catalog/test_serializers/test_request_serializer.py
+++ b/tests/test_service_catalog/test_serializers/test_request_serializer.py
@@ -1,0 +1,60 @@
+from django.test import TestCase
+
+from profiles.models import BillingGroup
+from service_catalog.models import Instance, Request
+from service_catalog.serializers.request_serializers import RequestSerializer
+from tests.test_service_catalog.base_test_request import BaseTestRequest
+
+
+class TestRequestSerializer(BaseTestRequest):
+
+    def setUp(self):
+        super(TestRequestSerializer, self).setUp()
+        self.local_test_instance = Instance.objects.create(name="test_instance_1",
+                                                           service=self.service_test,
+                                                           spoc=self.standard_user,
+                                                           billing_group=self.test_billing_group)
+
+        # add a first request
+        self.local_test_request = Request.objects.create(fill_in_survey={},
+                                                         instance=self.local_test_instance,
+                                                         operation=self.create_operation_test,
+                                                         user=self.standard_user)
+
+    def test_contains_expected_fields(self):
+        serializer = RequestSerializer(instance=self.local_test_request)
+        self.assertEqual(set(serializer.data.keys()),
+                         {'id', 'fill_in_survey', 'date_submitted', 'date_complete', 'date_archived',
+                          'instance', 'operation', 'state', 'tower_job_id', 'user'})
+
+    def test_request_serializer_field_content(self):
+        serializer = RequestSerializer(instance=self.local_test_request)
+        self.assertEqual(serializer.data['id'], self.local_test_request.id)
+        self.assertEqual(serializer.data['operation'], self.local_test_request.operation.id)
+        self.assertEqual(serializer.data['state'], self.local_test_request.state)
+
+        # instance object
+        self.assertEqual(serializer.data['instance']['id'],
+                         self.local_test_request.instance.id)
+        self.assertEqual(serializer.data['instance']['name'],
+                         self.local_test_request.instance.name)
+        self.assertEqual(serializer.data['instance']['service'],
+                         self.local_test_request.instance.service.id)
+        self.assertEqual(serializer.data['instance']['billing_group']['id'],
+                         self.local_test_request.instance.billing_group.id)
+        self.assertEqual(serializer.data['instance']['billing_group']['name'],
+                         self.local_test_request.instance.billing_group.name)
+
+        # user object
+        self.assertEqual(serializer.data['user']['id'],
+                         self.local_test_request.user.id)
+        self.assertEqual(serializer.data['user']['email'],
+                         self.local_test_request.user.email)
+        self.assertEqual(serializer.data['user']['username'],
+                         self.local_test_request.user.username)
+        self.assertEqual(serializer.data['user']['is_superuser'],
+                         self.local_test_request.user.is_superuser)
+        self.assertEqual(serializer.data['user']['is_staff'],
+                         self.local_test_request.user.is_staff)
+        self.assertEqual(serializer.data['user']['profile']['notification_enabled'],
+                         self.local_test_request.user.profile.notification_enabled)


### PR DESCRIPTION
So Tower playbook receive the billing group instead of an ID.