### PR TITLE
Replace Tower by AAP in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
     <img src="docs/images/squest_full_logo.png">
 </p>
 
-<h3 align="center">Self service portal on top of Ansible Tower/AWX</h3>
+<h3 align="center">Self service portal on top of Ansible Automation Platform(AAP)/AWX (formerly known as Ansible Tower)</h3>
 
 <p align="center">
 <a href="https://hewlettpackard.github.io/squest/latest"><img alt="Doc" src="https://img.shields.io/badge/read-documentation-1abc9c?style=flat-square"></a>
@@ -15,7 +15,7 @@
 
 Squest is a framework that allow you to expose an **Everything-as-a-Service** web portal. 
 
-Exposed services in Squest are not hard coded. A service is actually a pointer to your automation in the backend engine “Ansible Tower/AWX”. 
+Exposed services in Squest are not hard coded. A service is actually a pointer to your automation in the backend engine Ansible Automation Platform(AAP)/AWX (formerly known as Ansible Tower). 
 It means everything, as long as it exists as an automation script, can be exposed as a service. **The only limit is your own capability of automation**.
 
 More than a fire and forget tool, Squest can store in its database each deployed instance of services it has provisioned so you can attach to them more automation that allow 
@@ -30,7 +30,7 @@ If you want an idea of what you can do with Squest, click on the image below.
 ## Features
 
 - Service catalog:
-  - Add services to your catalog based on job templates you have in your Tower/AWX instance
+  - Add services to your catalog based on job templates you have in your Ansible Automation Platform/AWX instance
   - Manage requests for services (review, update, approve and process)
   - Manage lifecycle of each instance of a service
   - Integrated or external support page

--- a/docs/configuration/aap_awx_settings.md
+++ b/docs/configuration/aap_awx_settings.md
@@ -1,10 +1,10 @@
-# Tower configuration
+# AAP/AWX configuration
 
-Squest will need a token in order to communicate with your Tower instance.
+Squest will need a token in order to communicate with your AAP/AWX instance.
 
-## Create an application on your Tower/AWX instance
+## Create an application on your AAP/AWX instance
 
-On Tower, go in Application menu and create a new app with the following configuration:
+On AAP/AWX, go in Application menu and create a new app with the following configuration:
 
 - **name:** squest
 - **Organization:** Default  
@@ -13,11 +13,11 @@ On Tower, go in Application menu and create a new app with the following configu
 
 ## Create a token for Squest application
 
-On Tower/AWX:
+On AAP/AWX:
 
 - Go in your **Profile** page (top right corner), go into the tokens section
 - Click add button
 - Search for the "squest" application created previously and select it
 - Give a scope "write"
 - Save
-- Copy the generated token. This will be the token to give to Squest when creating a new Tower server instance.
+- Copy the generated token. This will be the token to give to Squest when creating a new AAP/AWX server instance.

--- a/docs/configuration/squest_settings.md
+++ b/docs/configuration/squest_settings.md
@@ -87,7 +87,7 @@ This can be used for example to block new requests by end users from the service
 
 **Default:** `http://squest.domain.local`
 
-Address of the Squest portal instance. Used in email templates and in metadata sent to Tower job templates.
+Address of the Squest portal instance. Used in email templates and in metadata sent to Ansible Automation Platform/AWX job templates.
 
 ### SQUEST_EMAIL_HOST
 

--- a/docs/dev/dev-env.md
+++ b/docs/dev/dev-env.md
@@ -31,7 +31,7 @@ The development environment is composed of 4 parts:
 
 - **Docker compose:** The Docker compose file is used to deploy all required components such as the database and the message broker
 - **Celery worker:** The Celery worker is a separated process that receive tasks from the main Django process to be executed asynchronously
-- **Celery beat:** Celery beat is a periodic task scheduler that send task into the celery worker based on a frequency. This part is used by Squest to check the status of executed Tower job
+- **Celery beat:** Celery beat is a periodic task scheduler that send task into the celery worker based on a frequency. This part is used by Squest to check the status of executed AAP/AWX job
 - **Django built in web server:** Integrated web server used only for development purpose. main process of the application that serve the Web Ui and the API
 
 ### Docker compose

--- a/docs/dev/plugins/validators.md
+++ b/docs/dev/plugins/validators.md
@@ -78,4 +78,4 @@ Update the `docker-compose.yml` file to add a volume that map your script folder
 
 In squest, go into `Service Catalog --> Manage Services --> Operations --> Survey`
 
-For each field of the Tower survey of the selected operation you can now add one or more validator.
+For each field of the AAP/AWX survey of the selected operation you can now add one or more validator.

--- a/docs/manual/resource_tracking.md
+++ b/docs/manual/resource_tracking.md
@@ -113,7 +113,7 @@ group** will be required, generating consumption on upper layers and so on...
 Resources can be created from the API. It allows to create automatically a new resource in a resource group when 
 something is provisioned from the service catalog.
 
-In the example below, the playbook executed in Tower/AWX would have created a VM. 
+In the example below, the playbook executed in AAP/AWX would have created a VM. 
 At the end of the process we call the squest API to instantiate a resource in the right resource group to reflect the 
 consumption.
 We link as well the pending instance(given by `squest.instance.id`) to this resource via the flag `service_catalog_instance`.

--- a/docs/manual/service_catalog/concept.md
+++ b/docs/manual/service_catalog/concept.md
@@ -1,8 +1,8 @@
 # Concept
 
-Once Squest is linked to a Tower/AWX server, "services" can be added into the catalog.
+Once Squest is linked to an AAP/AWX server, "services" can be added into the catalog.
 
-A service is composed of `operations` that are pointers to "job templates" present in Tower/AWX.
+A service is composed of `operations` that are pointers to "job templates" present in AAP/AWX.
 
 A service has at least one operation of type `CREATE` that allows to provision the resource.
 
@@ -11,7 +11,7 @@ A service can have then multiple operation of type `UPDATE` and `DELETE` that al
 ## Provisioning a service
 
 When a user request for the first time a service, an instance is created automatically and set to "pending" state on Squest.
-Once approved by the administrator, the request is sent to Tower to execute the linked job template.
+Once approved by the administrator, the request is sent to AAP/AWX to execute the linked job template.
 
 The executed job, aka the Ansible playbook, need to call back the Squest API in order to attach information (spec) to the pending instance.
 
@@ -21,16 +21,16 @@ sequenceDiagram
     participant User
     participant Admin
     participant Squest
-    participant Tower
+    participant AAP/AWX
     User->>Squest: Request service
     Admin->>Squest: Approve
     Admin->>Squest: Process
-    Squest->>Tower: Process
-    Squest-->>Tower: Check
-    Note right of Tower: Running
-    Tower->>Squest: Instance spec <br> {'uuid': 34, 'name': 'instance_name'}
-    Squest-->>Tower: Check
-    Note right of Tower: Successful    
+    Squest->>AAP/AWX: Process
+    Squest-->>AAP/AWX: Check
+    Note right of AAP/AWX: Running
+    AAP/AWX->>Squest: Instance spec <br> {'uuid': 34, 'name': 'instance_name'}
+    Squest-->>AAP/AWX: Check
+    Note right of AAP/AWX: Successful    
     Squest->>User: Notify service ready
 ```
 
@@ -114,7 +114,7 @@ Day 2 operations are operations that **update** or **delete** existing resources
 
 !!! note
 
-    By default, recent version of AWX/Tower drop extra variables that are not declared in the survey. To be able to receive Squest extra vars you need to enable "Prompt on Launch" in the "Variables" section of you job template. This correspond to the flag "ask_variables_on_launch" of the job_template model on the Tower/AWX API.
+    By default, recent version of AAP/AWX drop extra variables that are not declared in the survey. To be able to receive Squest extra vars you need to enable "Prompt on Launch" in the "Variables" section of you job template. This correspond to the flag "ask_variables_on_launch" of the job_template model on the AAP/AWX API.
 
 When a user creates a request for a day 2 operation of a provisioned instance, Squest automatically attach an `extra_vars` named `squest`
 that contains the instance spec sent by the playbook used to provision at first the resource.
@@ -127,16 +127,16 @@ sequenceDiagram
     participant User
     participant Admin
     participant Squest
-    participant Tower
+    participant AAP/AWX
     User->>Squest: Request update
     Admin->>Squest: Approve
     Admin->>Squest: Process
-    Squest->>Tower: Process - Extra vars:<br> {'squest': {'uuid': 34, 'name': 'instance_name'}}
-    Squest-->>Tower: Check
-    Note right of Tower: Running
-    Tower->>Squest: Instance spec update <br> {'uuid': 34, 'name': 'instance_new_name}
-    Squest-->>Tower: Check
-    Note right of Tower: Successful    
+    Squest->>AAP/AWX: Process - Extra vars:<br> {'squest': {'uuid': 34, 'name': 'instance_name'}}
+    Squest-->>AAP/AWX: Check
+    Note right of AAP/AWX: Running
+    AAP/AWX->>Squest: Instance spec update <br> {'uuid': 34, 'name': 'instance_new_name}
+    Squest-->>AAP/AWX: Check
+    Note right of AAP/AWX: Successful    
     Squest->>User: Notify service updated
 ```
 

--- a/docs/manual/service_catalog/operation.md
+++ b/docs/manual/service_catalog/operation.md
@@ -6,7 +6,7 @@
 |------------------------|-----------------------------------------------------------------------------------------------------------|
 | Name                   | Short name of the operation                                                                               |
 | Description            | Small description of the operation                                                                        |
-| Job template           | Executed job template in the backend Tower/AWX server                                                     |
+| Job template           | Executed job template in the backend AAP/AWX server                                                     |
 | Operation type         | Type of operation (Create, update, delete). Change the state of he instance after executing the operation |
 | Approval workflow      | Define an optional [approval workflow](#approval)                                                         |
 | Process timeout        | Number of second to wait for a successful return from the executed job template                           |
@@ -15,7 +15,7 @@
 | Enabled                | If set to `True` the operation can be requested from the UI and API                                       |
 | Is admin operation     | If set to `True` the operation is only visible and can be only requested by administrators                |
 | Extra vars             | Set of extra vars as JSON                                                                                 |
-| Default inventory ID   | ID of the Tower/AWX inventory to use by default.  Leave blank to use the default Job Template inventory   |
+| Default inventory ID   | ID of the AAP/AWX inventory to use by default.  Leave blank to use the default Job Template inventory   |
 | Default limit          | Comma separated list of inventory host limits                                                             |
 | Default tags           | Comma separated list of tags to use                                                                       |
 | Default skip tags      | Comma separated list of tags to skip                                                                      |
@@ -26,9 +26,9 @@
 
 ## Job template config
 
-By default, Squest will execute the selected Job Template with the config as set in Tower/AWX. 
+By default, Squest will execute the selected Job Template with the config as set in AAP/AWX. 
 
-If a field is configured to "Prompt on launch" in Tower/AWX, the administrator can override it from the "Process" page of an accepted request:
+If a field is configured to "Prompt on launch" in AAP/AWX, the administrator can override it from the "Process" page of an accepted request:
 
 Overridable fields:
 
@@ -50,14 +50,14 @@ Default value precedence:
 
 ```mermaid
 flowchart LR
-    Tower(Default from Tower/AWX) --> Squest(Default from Squest) --> Process(Process request page)
+    AAP/AWX(Default from AAP/AWX) --> Squest(Default from Squest) --> Process(Process request page)
 ```
 
 !!! note
 
-    **Default inventory ID** field is expecting an integer that correspond the the inventory ID in Tower/AWX.
+    **Default inventory ID** field is expecting an integer that correspond the the inventory ID in AAP/AWX.
 
-    **Default credential IDs** field is expecting a comma separated list of integer that correspond existings credentials ID in Tower/AWX.
+    **Default credential IDs** field is expecting a comma separated list of integer that correspond existings credentials ID in AAP/AWX.
 
 
 ## Approval
@@ -104,9 +104,9 @@ The survey of an operation can be edited to change the behavior of the generated
 
 !!! note
 
-    Surveys in Squest are actually surveys attached to each job templates in your Tower/AWX.
+    Surveys in Squest are actually surveys attached to each job templates in your AAP/AWX.
     Squest can only disable the ones that you don't want to be filled by your end users.
-    Those fields, if declared as mandatory on Tower/AWX, will need to be filled anyway by the admin when approving a request.
+    Those fields, if declared as mandatory on AAP/AWX, will need to be filled anyway by the admin when approving a request.
 
 ### End user field
 
@@ -115,24 +115,24 @@ By default, all fields are enabled when creating a new operation.
 
 !!! note
 
-    If the field is set as **required** into the Tower/AWX job template survey config then the administrator
+    If the field is set as **required** into the AAP/AWX job template survey config then the administrator
     will have to fill it in any case during the review of the request.
 
 ### Default value
 
 
-When set, the default value is pre-filled into the final form. It takes precedence over the default value set in Tower/AWX job template survey config.
+When set, the default value is pre-filled into the final form. It takes precedence over the default value set in AAP/AWX job template survey config.
 
 Default value precedence:
 
 ```mermaid
 flowchart LR
-    tower(Default from Tower/AWX) --> squest(Default from Squest value) --> User(User's input)  --> Admin(Admin's input)
+    AAP/AWX(Default from AAP/AWX) --> squest(Default from Squest value) --> User(User's input)  --> Admin(Admin's input)
 ```
 
 !!! note
 
-    When used with a 'multiple select' or 'multiple select multiple' type of field, the value need to be a valid one from the Tower/AWX survey field options.
+    When used with a 'multiple select' or 'multiple select multiple' type of field, the value need to be a valid one from the AAP/AWX survey field options.
 
 **Jinja templating**
 

--- a/docs/manual/service_catalog/service.md
+++ b/docs/manual/service_catalog/service.md
@@ -50,7 +50,7 @@ Squest will apply the following variable precedence:
 
 ```mermaid
 flowchart LR
-    survey(Request survey) --> Tower(Tower) --> Service(Service)  --> Operation(Operation)
+    survey(Request survey) --> AAP/AWX(AAP/AWX) --> Service(Service)  --> Operation(Operation)
 ```
 
 ## External support URL

--- a/docs/manual/tools.md
+++ b/docs/manual/tools.md
@@ -2,7 +2,7 @@
 
 ## Global Hooks
 
-Global hooks are a way to call a Tower/AWX job template following the new state of a `Request` or an `Instance`.
+Global hooks are a way to call a AAP/AWX job template following the new state of a `Request` or an `Instance`.
 
 For example, if you want to call a job template that performs an action everytime a `Request` switch to `FAILED` state.
 
@@ -11,7 +11,7 @@ Form field:
 - **name:** Name of your hook
 - **Model:** Target model object that will be linked to the hook (`Request` or an `Instance`)
 - **State:** State of the selected `model`. The hook will be triggered when an instance of the select model type will switch to this selected state
-- **Job template:** The Tower/AWX job template to execute when an instance of the selected model reach the selected state
+- **Job template:** The AAP/AWX job template to execute when an instance of the selected model reach the selected state
 - **Extra vars:** extra variable as JSON to add to the selected job template
 
 States documentation:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,7 +35,7 @@ nav:
     - Upgrade: installation/upgrade.md
   - Configuration:
     - Squest: configuration/squest_settings.md
-    - Tower: configuration/tower_settings.md
+    - AAP/AWX: configuration/aap_awx_settings.md
   - Manual:
     - Service catalog:
       - Concept: manual/service_catalog/concept.md

--- a/project-static/squest/js/squest.js
+++ b/project-static/squest/js/squest.js
@@ -264,7 +264,7 @@ function sync_job_template() {
         },
     }).done((res) => {
         $(document).Toasts('create', {
-            title: 'Job template sync from Ansible Controller',
+            title: 'Job template sync from AAP/AWX',
             body: 'Started',
             autohide: true,
             delay: 3000,
@@ -279,7 +279,7 @@ function sync_job_template() {
     }).fail((err) => {
         alert_error("Error during API call");
         $(document).Toasts('create', {
-            title: 'Job template sync from Ansible Controller',
+            title: 'Job template sync from AAP/AWX',
             body: 'Error',
             autohide: true,
             delay: 3000,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "squest"
 version = "2.0.0b"
-description = "Service catalog on top of Ansible Tower"
+description = "Service catalog on top of Ansible Automation Platform(AAP)/AWX (formerly known as Ansible Tower)"
 authors = ["Nicolas Marcq <nicolas.marcq@hpe.com>", "Elias Boulharts <elias.boulharts@hpe.com", "Anthony Belhadj <anthony.belhadj@hpe.com>"]
 license = "MIT"
 

--- a/service_catalog/migrations/0015_auto_20230728_1442.py
+++ b/service_catalog/migrations/0015_auto_20230728_1442.py
@@ -121,7 +121,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterModelOptions(
             name='towerserver',
-            options={'default_permissions': ('add', 'change', 'delete', 'view', 'list'), 'permissions': [('sync_towerserver', 'Can sync Controller')]},
+            options={'default_permissions': ('add', 'change', 'delete', 'view', 'list'), 'permissions': [('sync_towerserver', 'Can sync AAP/AWX')]},
         ),
         migrations.AlterModelOptions(
             name='towersurveyfield',

--- a/service_catalog/models/tower_server.py
+++ b/service_catalog/models/tower_server.py
@@ -10,7 +10,7 @@ from Squest.utils.squest_model import SquestModel
 class TowerServer(SquestModel):
     class Meta:
         permissions = [
-            ("sync_towerserver", "Can sync Controller"),
+            ("sync_towerserver", "Can sync AAP/AWX"),
         ]
         default_permissions = ('add', 'change', 'delete', 'view', 'list')
 

--- a/service_catalog/urls.py
+++ b/service_catalog/urls.py
@@ -100,23 +100,23 @@ urlpatterns = [
     path('doc/', views.DocListView.as_view(), name='doc_list'),
     path('doc/<int:pk>/', views.doc_details, name='doc_details'),
 
-    # Controller CRUD
-    path('controller/', views.TowerServerListView.as_view(), name='towerserver_list'),
-    path('controller/create/', views.TowerServerCreateView.as_view(), name='towerserver_create'),
-    path('controller/<int:pk>/', views.TowerServerDetailView.as_view(), name='towerserver_details'),
-    path('controller/<int:pk>/edit/', views.TowerServerEditView.as_view(), name='towerserver_edit'),
-    path('controller/<int:pk>/delete/', views.TowerServerDeleteView.as_view(), name='towerserver_delete'),
+    # Tower server CRUD
+    path('tower/', views.TowerServerListView.as_view(), name='towerserver_list'),
+    path('tower/create/', views.TowerServerCreateView.as_view(), name='towerserver_create'),
+    path('tower/<int:pk>/', views.TowerServerDetailView.as_view(), name='towerserver_details'),
+    path('tower/<int:pk>/edit/', views.TowerServerEditView.as_view(), name='towerserver_edit'),
+    path('tower/<int:pk>/delete/', views.TowerServerDeleteView.as_view(), name='towerserver_delete'),
 
-    # Synchronize controller endpoints
-    path('controller/<int:tower_id>/sync/', views.towerserver_sync, name='towerserver_sync'),
-    path('controller/<int:tower_id>/sync/<int:pk>', views.towerserver_sync, name='jobtemplate_sync'),
+    # Synchronize tower server endpoints
+    path('tower/<int:tower_id>/sync/', views.towerserver_sync, name='towerserver_sync'),
+    path('tower/<int:tower_id>/sync/<int:pk>', views.towerserver_sync, name='jobtemplate_sync'),
 
     # Job Template CRUD
-    path('controller/<int:tower_id>/job_template/', views.JobTemplateListView.as_view(),
+    path('tower/<int:tower_id>/job_template/', views.JobTemplateListView.as_view(),
          name='jobtemplate_list'),
     path('tower/<int:tower_id>/job_template/<int:pk>/', views.JobTemplateDetailView.as_view(),
          name='jobtemplate_details'),
-    path('controller/<int:tower_id>/job_template/<int:pk>/delete/', views.JobTemplateDeleteView.as_view(),
+    path('tower/<int:tower_id>/job_template/<int:pk>/delete/', views.JobTemplateDeleteView.as_view(),
          name='jobtemplate_delete'),
 
     # Job Template compliance details

--- a/service_catalog/views/job_template.py
+++ b/service_catalog/views/job_template.py
@@ -20,7 +20,7 @@ class JobTemplateListView(SquestListView):
         context = super().get_context_data(**kwargs)
         context['html_button_path'] = ""
         context['breadcrumbs'] = [
-            {'text': 'Controller', 'url': reverse('service_catalog:towerserver_list')},
+            {'text': 'Tower server', 'url': reverse('service_catalog:towerserver_list')},
             {'text': TowerServer.objects.get(id=self.kwargs.get('tower_id')).name, 'url': ""},
             {'text': 'Job templates', 'url': ""},
         ]
@@ -33,7 +33,7 @@ class JobTemplateDetailView(SquestDetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['breadcrumbs'] = [
-            {'text': 'Ansible Controller', 'url': reverse('service_catalog:towerserver_list')},
+            {'text': 'Tower server', 'url': reverse('service_catalog:towerserver_list')},
             {'text': self.get_object().tower_server.name, 'url': ""},
             {'text': 'Job templates', 'url': reverse('service_catalog:jobtemplate_list', args=[self.get_object().tower_server.id])},
             {'text': self.get_object(), 'url': ""},
@@ -50,7 +50,7 @@ class JobTemplateDeleteView(SquestDeleteView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['breadcrumbs'] = [
-            {'text': 'Ansible Controller', 'url': reverse('service_catalog:towerserver_list')},
+            {'text': 'Tower server', 'url': reverse('service_catalog:towerserver_list')},
             {'text': self.get_object().tower_server.name, 'url': ""},
             {'text': 'Job templates',
              'url': reverse('service_catalog:jobtemplate_list', args=[self.get_object().tower_server.id])},
@@ -67,7 +67,7 @@ def job_template_compliancy(request, tower_id, pk):
     if not request.user.has_perm('service_catalog.view_jobtemplate', job_template):
         raise PermissionDenied
     breadcrumbs = [
-        {'text': 'Ansible Controller', 'url': reverse('service_catalog:towerserver_list')},
+        {'text': 'Tower server', 'url': reverse('service_catalog:towerserver_list')},
         {'text': tower_server.name, 'url': ""},
         {'text': 'Job templates', 'url': reverse('service_catalog:jobtemplate_list', args=[tower_id])},
         {'text': job_template.name, 'url': ""},

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -166,7 +166,7 @@
                         <a href="{% url 'service_catalog:towerserver_list' %}"
                            class="nav-link {% if '/tower/' in request.path %}active{% endif %}">
                             <i class="nav-icon fas fa-chess-rook"></i>
-                            <p>Controllers</p>
+                            <p>Tower servers</p>
                         </a>
                     </li>
                 {% endif %}


### PR DESCRIPTION
Some questions remain unanswered:
- Should we rename the model "Tower" to something else? (e.g: AWX if we keep the main project name, AnsibleController if we don't want to refer to a product)
- Should we rename the model "TowerSurveyField" to SurveyField?
- Should we remove all Tower references (in model fields in particular)?

[Here](https://github.com/HewlettPackard/squest/pull/625/files) is an overview of what we should do .