### PR TITLE
Fix for k8s installer requirements.yml 

### DIFF
--- a/k8s/requirements.yml
+++ b/k8s/requirements.yml
@@ -1,3 +1,3 @@
 collections:
   - name: kubernetes.core
-    version: 2.3.2
+    version: 2.4.0


### PR DESCRIPTION
Based on the Ansible documentation for the kubernetes.core module version 2.4.0 is required to make use of the kubeconfig parameter that is used in setting up the helm charts. See [here](https://docs.ansible.com/ansible/latest/collections/kubernetes/core/helm_repository_module.html#parameter-kubeconfig) for the Ansible docs page. Let me know if there are any issues (Tested on one of my local k8s clusters)