### PR TITLE
[fix] k8s - django maintenance resolver

### DIFF
--- a/k8s/squest_k8s/tasks/05-django.yml
+++ b/k8s/squest_k8s/tasks/05-django.yml
@@ -237,6 +237,7 @@
               - ip: "127.0.0.1"
                 hostnames:
                   - "django"  # to match nginx config
+                  - "maintenance"  # to match nginx config
             initContainers:
               - name: wait-for-migration
                 image: ghcr.io/groundnuty/k8s-wait-for:v2.0


### PR DESCRIPTION
This fix simply adds `maintenance` host to resolv for 127.0.0.1, avoiding nginx failure when starting k8s pod

Logs when error occurs:
``` log
[root]@[mymachine]:[~]# kubectl logs django-b89b5bf97-4qrs2 -c nginx -n squest
2024/01/05 15:44:41 [emerg] 1#1: host not found in upstream "maintenance:80" in /etc/nginx/squest/nginx.conf:48
nginx: [emerg] host not found in upstream "maintenance:80" in /etc/nginx/squest/nginx.conf:48
```