### PR TITLE
Kubernetes: Fix file uploads

### DIFF
--- a/k8s/squest_k8s/tasks/05-django.yml
+++ b/k8s/squest_k8s/tasks/05-django.yml
@@ -229,6 +229,8 @@
               service: django
           spec:
             serviceAccountName: squest-sa
+            securityContext:
+              fsGroup: 999
             dnsConfig:
               options:
                 - name: ndots
@@ -260,6 +262,11 @@
                 envFrom:
                   - configMapRef:
                       name: django-env
+                volumeMounts:
+                  - mountPath: /app/media
+                    name: django-media
+                  - mountPath: /app/Squest/ldap_config.py
+                    name: ldap-config
               - name: nginx
                 image: nginx:1.23.4-alpine
                 command: ["nginx", "-c", "/etc/nginx/squest/nginx.conf"]
@@ -268,10 +275,13 @@
                 volumeMounts:
                   - name: nginx-config
                     mountPath: /etc/nginx/squest
+                    readOnly: true
                   - mountPath: /app/static
                     name: django-static
-                  - mountPath: /app/Squest/ldap_config.py
-                    name: ldap-config
+                    readOnly: true
+                  - name: django-media
+                    mountPath: /app/media
+                    readOnly: true
             restartPolicy: Always
             volumes:
               - name: django-media


### PR DESCRIPTION
- This fixes a server error caused by missing volumeMounts on the Squest container. A securityContext is needed too since the user ID is 999. 
- Also sets the volumes on the NGINX container to readOnly to match with the docker-compose deployment. 
- Move the ldap_config.py file to the Squest container.
- Add missing django-media volumeMounts