### PR TITLE
Added SMTP authentication parameters

### DIFF
--- a/Squest/settings.py
+++ b/Squest/settings.py
@@ -316,12 +316,17 @@ SQUEST_EMAIL_HOST = os.environ.get('SQUEST_EMAIL_HOST', "squest@squest.domain.lo
 SQUEST_EMAIL_NOTIFICATION_ENABLED = str_to_bool(os.environ.get('SQUEST_EMAIL_NOTIFICATION_ENABLED', False))
 EMAIL_HOST = os.environ.get('EMAIL_HOST', 'localhost')
 EMAIL_PORT = os.environ.get('EMAIL_PORT', 25)
+EMAIL_HOST_USER= os.environ.get('EMAIL_HOST_USER', None)
+EMAIL_HOST_PASSWORD= os.environ.get('EMAIL_HOST_PASSWORD', None)
+EMAIL_USE_SSL= os.environ.get('EMAIL_USE_SSL', False)
 
 print(f"SQUEST_HOST: {SQUEST_HOST}")
 print(f"SQUEST_EMAIL_HOST: {SQUEST_EMAIL_HOST}")
 print(f"SQUEST_EMAIL_NOTIFICATION_ENABLED: {SQUEST_EMAIL_NOTIFICATION_ENABLED}")
 print(f"EMAIL_HOST: {EMAIL_HOST}")
 print(f"EMAIL_PORT: {EMAIL_PORT}")
+print(f"EMAIL_HOST_USER: {EMAIL_HOST_USER}")
+print(f"EMAIL_USE_SSL: {EMAIL_USE_SSL}")
 
 # -----------------------------------------
 # Martor CONFIG https://github.com/agusmakmun/django-markdown-editor

--- a/docs/configuration/squest_settings.md
+++ b/docs/configuration/squest_settings.md
@@ -164,7 +164,7 @@ E.G: "Use your corporate email and password".
 
 ### MAINTENANCE_MODE_ENABLED
 
-**Default:** False
+**Default:** `False`
 
 When enabled, only administrators can access squest UI and API. 
 This can be used for example to block new requests by end users from the service catalog. So an administrator can perform operations against the API like migrating instance specs.
@@ -193,7 +193,7 @@ Set to `True` to enable email notifications.
 
 ### IS_DEV_SERVER
 
-**Default:** False
+**Default:** `False`
 
 Set to `True` to change the navbar and footer color to visually identify a testing instance of Squest.
 
@@ -213,19 +213,19 @@ Port to use for the SMTP server defined in `EMAIL_HOST`.
 
 ### EMAIL_HOST_USER
 
-**Default:** None
+**Default:** `None`
 
 User to use to authenticate with the SMTP server defined in `EMAIL_HOST` in combination with `EMAIL_HOST_PASSWORD`. Leave empty/unconfigured to send emails unauthenticated.
 
 ### EMAIL_HOST_PASSWORD
 
-**Default:** None
+**Default:** `None`
 
 Password to use to authenticate with the SMTP server defined in `EMAIL_HOST` in combination with `EMAIL_HOST_USER`. Leave empty/unconfigured to send emails unauthenticated.
 
 ### EMAIL_USE_SSL
 
-**Default:** False
+**Default:** `False`
 
 Whether to use an implicit TLS (secure) connection when talking to the SMTP server defined in `EMAIL_HOST`.
 
@@ -305,7 +305,7 @@ Django secret key used for cryptographic signing. [Doc](https://docs.djangoproje
 
 ### DEBUG
 
-**Default:** True
+**Default:** `True`
 
 Django DEBUG mode. Switch to `False` for production.
 

--- a/docs/configuration/squest_settings.md
+++ b/docs/configuration/squest_settings.md
@@ -209,7 +209,25 @@ The SMTP host to use for sending email.
 
 **Default:** `25`
 
-Port to use for the SMTP server defined in `EMAIL_HOST`.  
+Port to use for the SMTP server defined in `EMAIL_HOST`.
+
+### EMAIL_HOST_USER
+
+**Default:** None
+
+User to use to authenticate with the SMTP server defined in `EMAIL_HOST` in combination with `EMAIL_HOST_PASSWORD`. Leave empty/unconfigured to send emails unauthenticated.
+
+### EMAIL_HOST_PASSWORD
+
+**Default:** None
+
+Password to use to authenticate with the SMTP server defined in `EMAIL_HOST` in combination with `EMAIL_HOST_USER`. Leave empty/unconfigured to send emails unauthenticated.
+
+### EMAIL_USE_SSL
+
+**Default:** False
+
+Whether to use an implicit TLS (secure) connection when talking to the SMTP server defined in `EMAIL_HOST`.
 
 ## Backup
 


### PR DESCRIPTION
I added the parameters that are needed for authentication with the configured smtp server.

With these changes and defining the parameters in the squest.env file, I was able to send emails through an smtp server where authentication was necessary.
While I didn't explicitly test sending unauthenticated emails when the parameters are not configured, I don't think this should have an impact on it, since the values are set to the default values, when not configured.