### PR TITLE
squest_k8s role and playbooks: use module defaults

### DIFF
--- a/k8s/backup.yml
+++ b/k8s/backup.yml
@@ -9,6 +9,9 @@
 - name: "Execute a one shot backup of Squest"
   hosts: localhost
   gather_facts: true
+  module_defaults:
+    kubernetes.core.k8s:
+      kubeconfig: "{{ k8s_kubeconfig_path }}"
 
   tasks:
     - name: Generate job name
@@ -26,7 +29,6 @@
 
     - name: Wait until backup complete
       kubernetes.core.k8s_info:
-        kubeconfig: "{{ k8s_kubeconfig_path }}"
         api_version: "batch/v1"
         kind: Job
         name: "{{ job_name }}"
@@ -55,7 +57,6 @@
 
         - name: Wait until rsync backup complete
           kubernetes.core.k8s_info:
-            kubeconfig: "{{ k8s_kubeconfig_path }}"
             api_version: "batch/v1"
             kind: Job
             name: "{{ job_name }}"

--- a/k8s/deploy.yml
+++ b/k8s/deploy.yml
@@ -1,6 +1,9 @@
 - name: "Deploy Squest"
   hosts: localhost
   gather_facts: False
+  module_defaults:
+    kubernetes.core.k8s:
+      kubeconfig: "{{ k8s_kubeconfig_path }}"
 
   roles:
     - role: squest_k8s

--- a/k8s/squest_k8s/tasks/01-utils.yml
+++ b/k8s/squest_k8s/tasks/01-utils.yml
@@ -1,6 +1,5 @@
 - name: Install Prometheus operator CRDs
   kubernetes.core.helm:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     name: prometheus-operator-crds
     release_namespace: kube-system
     chart_version: "{{ prometheus_operator_crds_chart_version }}"
@@ -9,7 +8,6 @@
 
 - name: Wait until CRD is installed
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     api_version: "apiextensions.k8s.io/v1"
     kind: CustomResourceDefinition
     name: "prometheuses.monitoring.coreos.com"
@@ -23,7 +21,6 @@
 
 - name: Install Cert Manager
   kubernetes.core.helm:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     name: cert-manager
     release_namespace: cert-manager
     create_namespace: true
@@ -35,7 +32,6 @@
 
 - name: Wait until CRD is installed
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     api_version: "apiextensions.k8s.io/v1"
     kind: CustomResourceDefinition
     name: "certificates.cert-manager.io"
@@ -49,7 +45,6 @@
 
 - name: Wait until Cert manager deployment available
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     api_version: "apps/v1"
     kind: Deployment
     name: "cert-manager"

--- a/k8s/squest_k8s/tasks/02-db.yml
+++ b/k8s/squest_k8s/tasks/02-db.yml
@@ -1,6 +1,5 @@
 - name: Install MariaDB operator
   kubernetes.core.helm:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     name: mariadb-operator
     release_namespace: "{{ squest_namespace }}"
     chart_version: "{{ mariadb_operator_chart_version }}"
@@ -9,7 +8,6 @@
 
 - name: Wait until CRD is installed
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     api_version: "apiextensions.k8s.io/v1"
     kind: CustomResourceDefinition
     name: "mariadbs.mariadb.mmontes.io"
@@ -26,7 +24,6 @@
     - mariadb-operator
     - mariadb-operator-webhook
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     api_version: "apps/v1"
     kind: Deployment
     name: "{{ item }}"
@@ -40,7 +37,6 @@
 
 - name: Create a secret for mariadb
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     state: present
     namespace: "{{ squest_namespace }}"
     definition:
@@ -57,7 +53,6 @@
 
 - name: Deploy Maria DB
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     state: present
     namespace: "{{ squest_namespace }}"
     definition:
@@ -114,7 +109,6 @@
 
 - name: Wait until MariaDB deployment available
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     api_version: "mariadb.mmontes.io/v1alpha1"
     kind: "MariaDB"
     name: "mariadb"
@@ -131,7 +125,6 @@
   block:
     - name: Deploy PHPMyAdmin configmap environment
       kubernetes.core.k8s:
-        kubeconfig: "{{ k8s_kubeconfig_path }}"
         state: present
         definition:
           apiVersion: v1
@@ -146,7 +139,6 @@
 
     - name: PHPMyAdmin deployment
       kubernetes.core.k8s:
-        kubeconfig: "{{ k8s_kubeconfig_path }}"
         state: present
         definition:
           apiVersion: apps/v1
@@ -181,7 +173,6 @@
 
     - name: PHPMyAdmin service
       kubernetes.core.k8s:
-        kubeconfig: "{{ k8s_kubeconfig_path }}"
         state: present
         definition:
           apiVersion: v1
@@ -203,7 +194,6 @@
     - when: squest_phpmyadmin is defined and squest_phpmyadmin.ingress is defined and squest_phpmyadmin.ingress.enabled
       name: PHPMyAdmin ingress
       kubernetes.core.k8s:
-        kubeconfig: "{{ k8s_kubeconfig_path }}"
         state: present
         definition:
           apiVersion: networking.k8s.io/v1

--- a/k8s/squest_k8s/tasks/03-rabbitmq.yml
+++ b/k8s/squest_k8s/tasks/03-rabbitmq.yml
@@ -1,6 +1,5 @@
 - name: Install RabbitMQ operator
   kubernetes.core.helm:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     name: rabbitmq-cluster-operator
     release_namespace: "{{ squest_namespace }}"
     chart_version: "{{ rabbitmq_operator_chart_version }}"
@@ -9,7 +8,6 @@
 
 - name: Wait until CRD is installed
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     api_version: "apiextensions.k8s.io/v1"
     kind: CustomResourceDefinition
     name: "rabbitmqclusters.rabbitmq.com"
@@ -29,7 +27,6 @@
 
 - name: Deploy RabbitMQ messaging-topology-operator
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     state: present
     src: "/tmp/rabbitmq_topology_operator_manifest.yaml"
 
@@ -39,7 +36,6 @@
     - vhosts.rabbitmq.com
     - rabbitmqclusters.rabbitmq.com
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     api_version: "apiextensions.k8s.io/v1"
     kind: CustomResourceDefinition
     name: "{{ item }}"
@@ -53,7 +49,6 @@
 
 - name: RabbitMQ user password secret
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     state: present
     namespace: "{{ squest_namespace }}"
     definition:
@@ -71,7 +66,6 @@
 
 - name: RabbitMQ user
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     state: present
     namespace: "{{ squest_namespace }}"
     definition:
@@ -92,7 +86,6 @@
 
 - name: Deploy RabbitMQ cluster
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     state: present
     namespace: "{{ squest_namespace }}"
     definition:
@@ -135,7 +128,6 @@
 
 - name: RabbitMQ Squest vhost
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     state: present
     namespace: "{{ squest_namespace }}"
     definition:
@@ -154,7 +146,6 @@
 
 - name: Squest vHost permissions
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     state: present
     namespace: "{{ squest_namespace }}"
     definition:

--- a/k8s/squest_k8s/tasks/04-redis.yml
+++ b/k8s/squest_k8s/tasks/04-redis.yml
@@ -1,6 +1,5 @@
 - name: Install Redis operator
   kubernetes.core.helm:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     name: redis-operator
     release_namespace: "redis-operator"
     create_namespace: true
@@ -10,7 +9,6 @@
 
 - name: Wait until CRD is installed
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     api_version: "apiextensions.k8s.io/v1"
     kind: CustomResourceDefinition
     name: "redisreplications.redis.redis.opstreelabs.in"
@@ -24,7 +22,6 @@
 
 - name: Wait until deployment available
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     api_version: "apps/v1"
     kind: Deployment
     name: "redis-operator"
@@ -38,7 +35,6 @@
 
 - name: Redis password secret
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     state: present
     namespace: "{{ squest_namespace }}"
     definition:
@@ -54,7 +50,6 @@
 
 - name: Deploy Redis standalone server
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     state: present
     namespace: "{{ squest_namespace }}"
     definition:
@@ -101,7 +96,6 @@
 
 - name: Wait for StatefulSet to be ready
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     api_version: v1
     kind: StatefulSet
     namespace: "{{ squest_namespace }}"
@@ -113,7 +107,6 @@
 
 #- name: Deploy Redis cluster
 #  kubernetes.core.k8s:
-#    kubeconfig: "{{ k8s_kubeconfig_path }}"
 #    state: present
 #    namespace: "{{ squest_namespace }}"
 #    definition:

--- a/k8s/squest_k8s/tasks/05-django.yml
+++ b/k8s/squest_k8s/tasks/05-django.yml
@@ -1,6 +1,5 @@
 - name: Create a service account for Squest
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     namespace: "{{ squest_namespace }}"
     state: present
     definition:
@@ -15,7 +14,6 @@
 
 - name: Create a role allowed to get info on jobs
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     namespace: "{{ squest_namespace }}"
     state: present
     definition:
@@ -38,7 +36,6 @@
 
 - name: Link Squest service account to role
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     namespace: "{{ squest_namespace }}"
     state: present
     definition:
@@ -59,7 +56,6 @@
 
 - name: Django env as config map
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     namespace: "{{ squest_namespace }}"
     state: present
     definition:
@@ -78,7 +74,6 @@
     - "django-media"
     - "squest-backup"
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     namespace: "{{ squest_namespace }}"
     state: present
     definition:
@@ -98,7 +93,6 @@
 
 - name: Django database migration job
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     state: present
     namespace: "{{ squest_namespace }}"
     definition:
@@ -152,7 +146,6 @@
 
 - name: Wait until migration job done
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     api_version: "batch/v1"
     kind: Job
     name: "django-migrations"
@@ -166,7 +159,6 @@
 
 - name: Nginx config
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     state: present
     namespace: "{{ squest_namespace }}"
     definition:
@@ -187,7 +179,6 @@
 
 - name: LDAP config
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     state: present
     namespace: "{{ squest_namespace }}"
     definition:
@@ -203,7 +194,6 @@
 
 - name: Deploy Django app
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     state: present
     namespace: "{{ squest_namespace }}"
     definition:
@@ -306,7 +296,6 @@
 
 - name: Django service
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     state: present
     namespace: "{{ squest_namespace }}"
     definition:
@@ -326,7 +315,6 @@
 - when: squest_django.ingress.enabled
   name: Squest ingress
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     state: present
     namespace: "{{ squest_namespace }}"
     definition:
@@ -353,7 +341,6 @@
 
 - name: Wait until Django deployment available
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     api_version: "apps/v1"
     kind: Deployment
     name: "django"

--- a/k8s/squest_k8s/tasks/06-celery.yml
+++ b/k8s/squest_k8s/tasks/06-celery.yml
@@ -1,6 +1,5 @@
 - name: Deploy celery worker
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     state: present
     namespace: "{{ squest_namespace }}"
     definition:
@@ -55,7 +54,6 @@
 
 - name: Deploy celery beat
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     state: present
     namespace: "{{ squest_namespace }}"
     definition:

--- a/k8s/squest_k8s/tasks/07-maintenance.yml
+++ b/k8s/squest_k8s/tasks/07-maintenance.yml
@@ -1,6 +1,5 @@
 - name: Nginx maintenance config
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     state: present
     namespace: "{{ squest_namespace }}"
     definition:
@@ -20,7 +19,6 @@
 
 - name: Deploy maintenance static page
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     state: present
     namespace: "{{ squest_namespace }}"
     definition:
@@ -75,7 +73,6 @@
 
 - name: Maintenance service
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     state: present
     namespace: "{{ squest_namespace }}"
     definition:

--- a/k8s/squest_k8s/tasks/08-backup.yml
+++ b/k8s/squest_k8s/tasks/08-backup.yml
@@ -1,7 +1,6 @@
 - when: squest_django.backup.enabled
   name: Squest backup
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     state: present
     namespace: "{{ squest_namespace }}"
     definition:
@@ -56,7 +55,6 @@
   block:
     - name: Create a secret with the private ssh key
       kubernetes.core.k8s:
-        kubeconfig: "{{ k8s_kubeconfig_path }}"
         state: present
         namespace: "{{ squest_namespace }}"
         definition:
@@ -73,7 +71,6 @@
 
     - name: Create a cronjob for rsync external copy
       kubernetes.core.k8s:
-        kubeconfig: "{{ k8s_kubeconfig_path }}"
         state: present
         namespace: "{{ squest_namespace }}"
         definition:

--- a/k8s/squest_k8s/tasks/main.yml
+++ b/k8s/squest_k8s/tasks/main.yml
@@ -1,6 +1,5 @@
 - name: Create a dedicated namespace for Squest
   kubernetes.core.k8s:
-    kubeconfig: "{{ k8s_kubeconfig_path }}"
     state: present
     definition:
       apiVersion: v1

--- a/k8s/update.yml
+++ b/k8s/update.yml
@@ -1,11 +1,13 @@
 - name: "Update Squest"
   hosts: localhost
   gather_facts: False
+  module_defaults:
+    kubernetes.core.k8s:
+      kubeconfig: "{{ k8s_kubeconfig_path }}"
 
   tasks:
     - name: Update ingress to point to maintenance pod
       kubernetes.core.k8s:
-        kubeconfig: "{{ k8s_kubeconfig_path }}"
         state: patched
         namespace: "{{ squest_namespace }}"
         definition:
@@ -32,7 +34,6 @@
 
     - name: Update Django env config map
       kubernetes.core.k8s:
-        kubeconfig: "{{ k8s_kubeconfig_path }}"
         namespace: "{{ squest_namespace }}"
         state: patched
         definition:
@@ -47,7 +48,6 @@
 
     - name: Delete migration job
       kubernetes.core.k8s:
-        kubeconfig: "{{ k8s_kubeconfig_path }}"
         namespace: "{{ squest_namespace }}"
         kind: Job
         api_version: batch/v1
@@ -56,7 +56,6 @@
 
     - name: Create back Django database migration job
       kubernetes.core.k8s:
-        kubeconfig: "{{ k8s_kubeconfig_path }}"
         state: present
         namespace: "{{ squest_namespace }}"
         definition:
@@ -118,7 +117,6 @@
         - celery-worker
         - celery-beat
       kubernetes.core.k8s:
-        kubeconfig: "{{ k8s_kubeconfig_path }}"
         namespace: "{{ squest_namespace }}"
         kind: Deployment
         name: "{{ item }}"
@@ -140,7 +138,6 @@
         - celery-worker
         - celery-beat
       kubernetes.core.k8s_info:
-        kubeconfig: "{{ k8s_kubeconfig_path }}"
         api_version: "apps/v1"
         kind: Deployment
         name: "{{ item }}"
@@ -154,7 +151,6 @@
 
     - name: Restore ingress
       kubernetes.core.k8s:
-        kubeconfig: "{{ k8s_kubeconfig_path }}"
         state: patched
         namespace: "{{ squest_namespace }}"
         definition:


### PR DESCRIPTION
Setting the `module_defaults` in the playbook avoids having to set the same setting over and over. Makes things a little easier to read...

Even if the role should be split out and published later, people can always set this in their playbooks when using the role.