### PR TITLE
make ansible-lint (almost) happy

### DIFF
--- a/k8s/.ansible-lint
+++ b/k8s/.ansible-lint
@@ -1,0 +1,18 @@
+---
+
+profile: production
+
+skip_list:
+  - key-order
+  - no-changed-when
+  - yaml[line-length]
+
+enable_list:
+  - args
+  - empty-string-compare # opt-in
+  - no-log-password # opt-in
+  - no-same-owner # opt-in
+  - galaxy-version-incorrect # opt-in
+  # add yaml here if you want to avoid ignoring yaml checks when yamllint
+  # library is missing. Normally its absence just skips using that rule.
+  - yaml

--- a/k8s/backup.yml
+++ b/k8s/backup.yml
@@ -25,7 +25,7 @@
         job_name: "backup-{{ ansible_date_time.iso8601_basic_short }}"
 
     - name: Create Job from backup cronjob
-      shell: "kubectl --namespace {{ squest_namespace }} create job --from=cronjob/squest-backup {{ job_name }}"
+      ansible.builtin.command: "kubectl --namespace {{ squest_namespace }} create job --from=cronjob/squest-backup {{ job_name }}"
       environment:
         KUBECONFIG: "{{ k8s_kubeconfig_path }}"
       register: register_backup
@@ -39,7 +39,7 @@
         kind: Job
         name: "{{ job_name }}"
         namespace: "{{ squest_namespace }}"
-        wait: yes
+        wait: true
         wait_sleep: 10
         wait_timeout: 120
         wait_condition:
@@ -47,13 +47,14 @@
           status: "True"
 
     - when: squest_django.externalize_backup_via_rsync.enabled
+      name: Block for external backup
       block:
         - name: Generate job name
           ansible.builtin.set_fact:
             job_name: "rsync-backup-{{ ansible_date_time.iso8601_basic_short }}"
 
         - name: Create Job from rsync backup cronjob
-          shell: "kubectl --namespace {{ squest_namespace }} create job --from=cronjob/squest-rsync-backup {{ job_name }}"
+          ansible.builtin.command: "kubectl --namespace {{ squest_namespace }} create job --from=cronjob/squest-rsync-backup {{ job_name }}"
           environment:
             KUBECONFIG: "{{ k8s_kubeconfig_path }}"
           register: register_backup
@@ -67,7 +68,7 @@
             kind: Job
             name: "{{ job_name }}"
             namespace: "{{ squest_namespace }}"
-            wait: yes
+            wait: true
             wait_sleep: 10
             wait_timeout: 120
             wait_condition:

--- a/k8s/deploy.yml
+++ b/k8s/deploy.yml
@@ -1,6 +1,6 @@
 - name: "Deploy Squest"
   hosts: localhost
-  gather_facts: False
+  gather_facts: false
   module_defaults:
     kubernetes.core.k8s:
       kubeconfig: "{{ k8s_kubeconfig_path }}"

--- a/k8s/squest_k8s/tasks/01-utils.yml
+++ b/k8s/squest_k8s/tasks/01-utils.yml
@@ -12,7 +12,7 @@
     kind: CustomResourceDefinition
     name: "prometheuses.monitoring.coreos.com"
     namespace: "default"
-    wait: yes
+    wait: true
     wait_sleep: 10
     wait_timeout: 600
     wait_condition:
@@ -36,7 +36,7 @@
     kind: CustomResourceDefinition
     name: "certificates.cert-manager.io"
     namespace: "default"
-    wait: yes
+    wait: true
     wait_sleep: 10
     wait_timeout: 600
     wait_condition:
@@ -49,7 +49,7 @@
     kind: Deployment
     name: "cert-manager"
     namespace: "cert-manager"
-    wait: yes
+    wait: true
     wait_sleep: 10
     wait_timeout: 600
     wait_condition:

--- a/k8s/squest_k8s/tasks/02-db.yml
+++ b/k8s/squest_k8s/tasks/02-db.yml
@@ -12,7 +12,7 @@
     kind: CustomResourceDefinition
     name: "mariadbs.mariadb.mmontes.io"
     namespace: "{{ squest_namespace }}"
-    wait: yes
+    wait: true
     wait_sleep: 10
     wait_timeout: 600
     wait_condition:
@@ -28,7 +28,7 @@
     kind: Deployment
     name: "{{ item }}"
     namespace: "{{ squest_namespace }}"
-    wait: yes
+    wait: true
     wait_sleep: 10
     wait_timeout: 600
     wait_condition:
@@ -48,8 +48,8 @@
           app: squest
           service: mariadb
       data:
-        root-password: "{{ squest_db.root_password |b64encode }}"
-        password: "{{ squest_db.password |b64encode }}"
+        root-password: "{{ squest_db.root_password | b64encode }}"
+        password: "{{ squest_db.password | b64encode }}"
 
 - name: Deploy Maria DB
   kubernetes.core.k8s:
@@ -113,7 +113,7 @@
     kind: "MariaDB"
     name: "mariadb"
     namespace: "{{ squest_namespace }}"
-    wait: yes
+    wait: true
     wait_sleep: 10
     wait_timeout: 600
     wait_condition:
@@ -122,6 +122,7 @@
 
 
 - when: squest_phpmyadmin.enabled
+  name: Block for phpmyadmin deployment
   block:
     - name: Deploy PHPMyAdmin configmap environment
       kubernetes.core.k8s:

--- a/k8s/squest_k8s/tasks/03-rabbitmq.yml
+++ b/k8s/squest_k8s/tasks/03-rabbitmq.yml
@@ -12,7 +12,7 @@
     kind: CustomResourceDefinition
     name: "rabbitmqclusters.rabbitmq.com"
     namespace: "{{ squest_namespace }}"
-    wait: yes
+    wait: true
     wait_sleep: 10
     wait_timeout: 600
     wait_condition:
@@ -40,7 +40,7 @@
     kind: CustomResourceDefinition
     name: "{{ item }}"
     namespace: "{{ squest_namespace }}"
-    wait: yes
+    wait: true
     wait_sleep: 10
     wait_timeout: 600
     wait_condition:

--- a/k8s/squest_k8s/tasks/04-redis.yml
+++ b/k8s/squest_k8s/tasks/04-redis.yml
@@ -13,7 +13,7 @@
     kind: CustomResourceDefinition
     name: "redisreplications.redis.redis.opstreelabs.in"
     namespace: "{{ squest_namespace }}"
-    wait: yes
+    wait: true
     wait_sleep: 10
     wait_timeout: 600
     wait_condition:
@@ -26,7 +26,7 @@
     kind: Deployment
     name: "redis-operator"
     namespace: "redis-operator"
-    wait: yes
+    wait: true
     wait_sleep: 10
     wait_timeout: 600
     wait_condition:
@@ -105,51 +105,51 @@
   delay: 2
   retries: 10
 
-#- name: Deploy Redis cluster
-#  kubernetes.core.k8s:
-#    state: present
-#    namespace: "{{ squest_namespace }}"
-#    definition:
-#      apiVersion: redis.redis.opstreelabs.in/v1beta2
-#      kind: RedisCluster
-#      metadata:
-#        name: redis-cluster
-#      spec:
-#        clusterSize: 3
-#        clusterVersion: v7
-#        podSecurityContext:
-#          runAsUser: 1000
-#          fsGroup: 1000
-#        persistenceEnabled: false
-#        kubernetesConfig:
-#          image: quay.io/opstree/redis:v7.0.12
-#          imagePullPolicy: IfNotPresent
-#          redisSecret:
-#            name: redis-secret
-#            key: password
-#        redisExporter:
-#          enabled: false
-#          image: quay.io/opstree/redis-exporter:v1.44.0
-#        storage:
-#          nodeConfVolume: true
-#          volumeMount:
-#            volume:
-#              - name: data
-#                emptyDir:
-#                  sizeLimit: 1Gi
-#            mountPath:
-#              - mountPath: /data
-#                name: data
-#          volumeClaimTemplate:
-#            spec:
-#              # storageClassName: standard
-#              accessModes: ["ReadWriteOnce"]
-#              resources:
-#                requests:
-#                  storage: 1Gi
-#          nodeConfVolumeClaimTemplate:
-#            spec:
-#              accessModes: ["ReadWriteOnce"]
-#              resources:
-#                requests:
-#                  storage: 1Gi
+# - name: Deploy Redis cluster
+#   kubernetes.core.k8s:
+#     state: present
+#     namespace: "{{ squest_namespace }}"
+#     definition:
+#       apiVersion: redis.redis.opstreelabs.in/v1beta2
+#       kind: RedisCluster
+#       metadata:
+#         name: redis-cluster
+#       spec:
+#         clusterSize: 3
+#         clusterVersion: v7
+#         podSecurityContext:
+#           runAsUser: 1000
+#           fsGroup: 1000
+#         persistenceEnabled: false
+#         kubernetesConfig:
+#           image: quay.io/opstree/redis:v7.0.12
+#           imagePullPolicy: IfNotPresent
+#           redisSecret:
+#             name: redis-secret
+#             key: password
+#         redisExporter:
+#           enabled: false
+#           image: quay.io/opstree/redis-exporter:v1.44.0
+#         storage:
+#           nodeConfVolume: true
+#           volumeMount:
+#             volume:
+#               - name: data
+#                 emptyDir:
+#                   sizeLimit: 1Gi
+#             mountPath:
+#               - mountPath: /data
+#                 name: data
+#           volumeClaimTemplate:
+#             spec:
+#               # storageClassName: standard
+#               accessModes: ["ReadWriteOnce"]
+#               resources:
+#                 requests:
+#                   storage: 1Gi
+#           nodeConfVolumeClaimTemplate:
+#             spec:
+#               accessModes: ["ReadWriteOnce"]
+#               resources:
+#                 requests:
+#                   storage: 1Gi

--- a/k8s/squest_k8s/tasks/05-django.yml
+++ b/k8s/squest_k8s/tasks/05-django.yml
@@ -118,7 +118,7 @@
                     echo $UID
                     echo $USER
                     echo ""
-                    echo "-----------------------------------------------------"                    
+                    echo "-----------------------------------------------------"
                     echo "Wait for required services to start"
                     /wait
                     echo "Applying database migration"
@@ -150,7 +150,7 @@
     kind: Job
     name: "django-migrations"
     namespace: "{{ squest_namespace }}"
-    wait: yes
+    wait: true
     wait_sleep: 10
     wait_timeout: 600
     wait_condition:
@@ -175,7 +175,12 @@
 
 - name: Set the path of the ldap config from the user config or use default
   ansible.builtin.set_fact:
-    ldap_config_file_content: "{% if 'ldap' in squest_django  %}{{ squest_django.ldap.ldap_config_file }}{% else %}{{ lookup('file', playbook_dir + '/../Squest/ldap_config.py') }}{% endif %}"
+    ldap_config_file_content: |
+      {% if 'ldap' in squest_django %}
+      {{ squest_django.ldap.ldap_config_file }}
+      {% else %}
+      {{ lookup('file', playbook_dir + '/../Squest/ldap_config.py') }}
+      {% endif %}
 
 - name: LDAP config
   kubernetes.core.k8s:
@@ -308,9 +313,9 @@
           app: squest
           service: django
         ports:
-        - protocol: TCP
-          port: 8080
-          targetPort: 8080
+          - protocol: TCP
+            port: 8080
+            targetPort: 8080
 
 - when: squest_django.ingress.enabled
   name: Squest ingress
@@ -345,7 +350,7 @@
     kind: Deployment
     name: "django"
     namespace: "{{ squest_namespace }}"
-    wait: yes
+    wait: true
     wait_sleep: 10
     wait_timeout: 600
     wait_condition:

--- a/k8s/squest_k8s/tasks/07-maintenance.yml
+++ b/k8s/squest_k8s/tasks/07-maintenance.yml
@@ -15,7 +15,7 @@
         nginx.conf: "{{ lookup('file', playbook_dir + '/../docker/maintenance.nginx.conf') }}"
         maintenance.html: "{{ lookup('file', playbook_dir + '/../docker/maintenance.html') }}"
       binaryData:
-        squest_logo_v2_300_300.png: "{{ lookup('file', playbook_dir + '/../project-static/squest/img/squest_logo_v2_300_300.png')  |b64encode }}"
+        squest_logo_v2_300_300.png: "{{ lookup('file', playbook_dir + '/../project-static/squest/img/squest_logo_v2_300_300.png') | b64encode }}"
 
 - name: Deploy maintenance static page
   kubernetes.core.k8s:
@@ -85,6 +85,6 @@
           app: squest
           service: maintenance
         ports:
-        - protocol: TCP
-          port: 80
-          targetPort: 80
+          - protocol: TCP
+            port: 80
+            targetPort: 80

--- a/k8s/squest_k8s/tasks/08-backup.yml
+++ b/k8s/squest_k8s/tasks/08-backup.yml
@@ -52,6 +52,7 @@
                       claimName: squest-backup
 
 - when: squest_django.externalize_backup_via_rsync.enabled
+  name: Block for cronjob
   block:
     - name: Create a secret with the private ssh key
       kubernetes.core.k8s:
@@ -67,7 +68,7 @@
               service: backup
           type: Opaque
           data:
-            ssh.key: "{{ squest_django.externalize_backup_via_rsync.private_ssh_key |b64encode }}"
+            ssh.key: "{{ squest_django.externalize_backup_via_rsync.private_ssh_key | b64encode }}"
 
     - name: Create a cronjob for rsync external copy
       kubernetes.core.k8s:
@@ -96,13 +97,14 @@
                       - name: rsync
                         image: instrumentisto/rsync-ssh:alpine3.18
                         imagePullPolicy: Always
-                        command: ["/bin/sh","-c", "-x"]
+                        command: ["/bin/sh", "-c", "-x"]
                         args:
                           - |
                             rsync \
                             -avz --ignore-existing --delete \
                             -e "ssh -i /root/.ssh/ssh.key -o StrictHostKeyChecking=no" \
-                            /app/backup {{ squest_django.externalize_backup_via_rsync.ssh_user }}@{{ squest_django.externalize_backup_via_rsync.ssh_server }}:{{ squest_django.externalize_backup_via_rsync.remote_path }}
+                            /app/backup \
+                            {{ squest_django.externalize_backup_via_rsync.ssh_user }}@{{ squest_django.externalize_backup_via_rsync.ssh_server }}:{{ squest_django.externalize_backup_via_rsync.remote_path }}
                         volumeMounts:
                           - name: squest-rsync-ssh-key
                             mountPath: /root/.ssh/
@@ -114,5 +116,5 @@
                           claimName: squest-backup
                       - name: squest-rsync-ssh-key
                         secret:
-                          defaultMode: 0600
+                          defaultMode: "0600"
                           secretName: squest-rsync-ssh-key

--- a/k8s/update.yml
+++ b/k8s/update.yml
@@ -1,6 +1,6 @@
 - name: "Update Squest"
   hosts: localhost
-  gather_facts: False
+  gather_facts: false
   module_defaults:
     kubernetes.core.k8s:
       kubeconfig: "{{ k8s_kubeconfig_path }}"
@@ -86,7 +86,7 @@
                         echo $UID
                         echo $USER
                         echo ""
-                        echo "-----------------------------------------------------"                    
+                        echo "-----------------------------------------------------"
                         echo "Wait for required services to start"
                         /wait
                         echo "Applying database migration"
@@ -147,7 +147,7 @@
         kind: Deployment
         name: "{{ item }}"
         namespace: "{{ squest_namespace }}"
-        wait: yes
+        wait: true
         wait_sleep: 10
         wait_timeout: 600
         wait_condition:


### PR DESCRIPTION
(Separate commits for easier review)

Lots of small things, only two tasks were changed from `shell` to `command`.

The only things still present are these:

```bash
$ cd k8s
$ ansible-lint --offline --profile=production
WARNING  Listing 9 violation(s) that are fatal
no-changed-when: Commands should not change things if nothing needs doing.
backup.yml:21 Task/Handler: Create Job from backup cronjob

key-order[task]: You can improve the task key order to: name, when, block
backup.yml:43 Task/Handler: Block for external backup

no-changed-when: Commands should not change things if nothing needs doing.
backup.yml:50 Task/Handler: Create Job from rsync backup cronjob

yaml[line-length]: Line too long (216 > 160 characters)
squest_k8s/defaults/main.yml:10

key-order[task]: You can improve the task key order to: name, when, block
squest_k8s/tasks/02-db.yml:124 Task/Handler: Block for phpmyadmin deployment

key-order[task]: You can improve the task key order to: name, when, kubernetes.core.k8s
squest_k8s/tasks/02-db.yml:195 Task/Handler: PHPMyAdmin ingress

key-order[task]: You can improve the task key order to: name, when, kubernetes.core.k8s
squest_k8s/tasks/05-django.yml:320 Task/Handler: Squest ingress

key-order[task]: You can improve the task key order to: name, when, kubernetes.core.k8s
squest_k8s/tasks/08-backup.yml:1 Task/Handler: Squest backup

yaml[line-length]: Line too long (206 > 160 characters)
squest_k8s/tasks/08-backup.yml:107

Read documentation for instructions on how to ignore specific rule violations.

# Rule Violation Summary

  5 key-order profile:basic tags:formatting
  2 yaml profile:basic tags:formatting,yaml
  2 no-changed-when profile:basic tags:command-shell,idempotency

Failed: 9 failure(s), 0 warning(s) on 16 files. Profile 'production' was required, but 'min' profile passed.

$
```