### PR TITLE
k8s/squest_k8s/tasks/05-django.yml: fix mountPath for ldap_config.py

### DIFF
--- a/k8s/squest_k8s/tasks/05-django.yml
+++ b/k8s/squest_k8s/tasks/05-django.yml
@@ -260,7 +260,7 @@
                 volumeMounts:
                   - mountPath: /app/media
                     name: django-media
-                  - mountPath: /app/Squest/ldap_config.py
+                  - mountPath: /app/Squest/
                     name: ldap-config
               - name: nginx
                 image: nginx:1.23.4-alpine


### PR DESCRIPTION
fix mountPath for ldap_config.py to not use the full path

Otherwise I get this error (in `kubectl describe pod ...`):

```
Warning  Failed     36s (x5 over 2m9s)   kubelet            Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mount
ing "/var/lib/kubelet/pods/100aa995-9f8b-4ade-aa35-1d7d8d5406af/volumes/kubernetes.io~configmap/ldap-config" to rootfs at "/app/Squest/ldap_config.py": create mountpoint for /app/Squest/ldap_config.py mount: cannot create subdirectories in "/run/k3s/con
tainerd/io.containerd.runtime.v2.task/k8s.io/django/rootfs/app/Squest/ldap_config.py": not a directory
```