### PR TITLE
Add ALLOWED_HOSTS to squest.env

### DIFF
--- a/docker/environment_variables/squest.env
+++ b/docker/environment_variables/squest.env
@@ -39,3 +39,6 @@ RABBITMQ_VHOST=squest
 # BACKUP_CRONTAB=0 1 * * *
 
 GUNICORN_WORKERS=4
+
+## Reverse Proxy
+ALLOWED_HOSTS="squest.domain.local"


### PR DESCRIPTION
Add ALLOWED_HOSTS to squest.env so it matches the documentation (https://hewlettpackard.github.io/squest/2.8.4/installation/docker-compose/) about updating ALLOWED_HOSTS